### PR TITLE
Add SOCKS5 proxy configuration for SIP signaling

### DIFF
--- a/belle-sip/include/belle-sip/sipstack.h
+++ b/belle-sip/include/belle-sip/sipstack.h
@@ -264,6 +264,10 @@ BELLESIP_EXPORT void belle_sip_stack_set_http_proxy_host(belle_sip_stack_t *stac
 BELLESIP_EXPORT void belle_sip_stack_set_http_proxy_port(belle_sip_stack_t *stack, int port);
 BELLESIP_EXPORT const char *belle_sip_stack_get_http_proxy_host(const belle_sip_stack_t *stack);
 BELLESIP_EXPORT int belle_sip_stack_get_http_proxy_port(const belle_sip_stack_t *stack);
+BELLESIP_EXPORT void belle_sip_stack_set_socks5_proxy_host(belle_sip_stack_t *stack, const char *proxy_addr);
+BELLESIP_EXPORT void belle_sip_stack_set_socks5_proxy_port(belle_sip_stack_t *stack, int port);
+BELLESIP_EXPORT const char *belle_sip_stack_get_socks5_proxy_host(const belle_sip_stack_t *stack);
+BELLESIP_EXPORT int belle_sip_stack_get_socks5_proxy_port(const belle_sip_stack_t *stack);
 
 /**
  * Enable the reconnection to the primary server when it is up again as soon as possible.

--- a/belle-sip/src/belle_sip_internal.h
+++ b/belle-sip/src/belle_sip_internal.h
@@ -728,6 +728,8 @@ struct belle_sip_stack {
 	int http_proxy_port;
 	char *http_proxy_username; /*for future use*/
 	char *http_proxy_passwd;   /*for future use*/
+	char *socks5_proxy_host;
+	int socks5_proxy_port;
 	belle_sip_digest_authentication_policy_t *digest_auth_policy;
 
 	int refresh_window_min; /*lower bound of the refresh window */

--- a/belle-sip/src/sipstack.c
+++ b/belle-sip/src/sipstack.c
@@ -171,6 +171,7 @@ static void belle_sip_stack_destroy(belle_sip_stack_t *stack) {
 	if (stack->http_proxy_host) belle_sip_free(stack->http_proxy_host);
 	if (stack->http_proxy_passwd) belle_sip_free(stack->http_proxy_passwd);
 	if (stack->http_proxy_username) belle_sip_free(stack->http_proxy_username);
+	if (stack->socks5_proxy_host) belle_sip_free(stack->socks5_proxy_host);
 	belle_sip_list_free_with_data(stack->dns_servers, belle_sip_free);
 #ifdef HAVE_DNS_SERVICE
 	if (stack->dns_service_queue) {
@@ -474,6 +475,8 @@ int belle_sip_stack_content_encoding_available(belle_sip_stack_t *stack, const c
 
 GET_SET_STRING(belle_sip_stack, http_proxy_host)
 GET_SET_INT(belle_sip_stack, http_proxy_port, int)
+GET_SET_STRING(belle_sip_stack, socks5_proxy_host)
+GET_SET_INT(belle_sip_stack, socks5_proxy_port, int)
 
 void belle_sip_set_log_handler(belle_sip_log_function_t func) {
 	bctbx_set_log_handler_for_domain(func, BCTBX_LOG_DOMAIN);

--- a/belle-sip/src/transports/stream_channel.c
+++ b/belle-sip/src/transports/stream_channel.c
@@ -35,6 +35,7 @@ static int stream_channel_process_data(belle_sip_stream_channel_t *obj, unsigned
 
 static void stream_channel_uninit(belle_sip_stream_channel_t *obj) {
 	belle_sip_socket_t sock = belle_sip_source_get_socket((belle_sip_source_t *)obj);
+	if (obj->socks5_proxy_resolver_ctx) belle_sip_object_unref(obj->socks5_proxy_resolver_ctx);
 	if (sock != (belle_sip_socket_t)-1) stream_channel_close(obj);
 }
 
@@ -120,7 +121,96 @@ static void stream_channel_enable_ios_background_mode(belle_sip_stream_channel_t
 
 #endif
 
-int stream_channel_connect(belle_sip_stream_channel_t *obj, const struct addrinfo *ai) {
+int stream_channel_socks5_proxy_enabled(const belle_sip_stream_channel_t *obj) {
+	return obj->base.stack->socks5_proxy_host && obj->base.stack->socks5_proxy_host[0] != '\0';
+}
+
+static int socks5_proxy_port(const belle_sip_stack_t *stack) {
+	return stack->socks5_proxy_port > 0 ? stack->socks5_proxy_port : 1080;
+}
+
+int stream_channel_start_socks5_connect(belle_sip_stream_channel_t *obj) {
+	int ret;
+
+	ret = stream_channel_send(obj, "\x05\x01\x00", 3);
+	if (ret != 3) return -1;
+	obj->socks5_proxy_waiting_for_connect_response = 1;
+	obj->socks5_proxy_response_len = 0;
+	return 0;
+}
+
+static int socks5_recv_until(belle_sip_stream_channel_t *obj, size_t expected) {
+	int ret;
+
+	if (obj->socks5_proxy_response_len >= expected) return 0;
+	ret = stream_channel_recv(obj, obj->socks5_proxy_response + obj->socks5_proxy_response_len,
+	                          sizeof(obj->socks5_proxy_response) - obj->socks5_proxy_response_len);
+	if (ret <= 0) return -1;
+	obj->socks5_proxy_response_len += (size_t)ret;
+	return obj->socks5_proxy_response_len >= expected ? 0 : 1;
+}
+
+int stream_channel_process_socks5_response(belle_sip_stream_channel_t *obj) {
+	unsigned char request[4 + 255 + 2];
+	unsigned char atyp;
+	size_t hostlen;
+	size_t request_len;
+	size_t expected_len;
+	int ret;
+
+	if (obj->socks5_proxy_waiting_for_connect_response == 1) {
+		ret = socks5_recv_until(obj, 2);
+		if (ret != 0) return ret;
+		if (obj->socks5_proxy_response[0] != 0x05 || obj->socks5_proxy_response[1] != 0x00) {
+			belle_sip_error("SOCKS5 proxy [%s:%i] rejected authentication method", obj->base.stack->socks5_proxy_host,
+			                socks5_proxy_port(obj->base.stack));
+			return -1;
+		}
+		hostlen = strlen(obj->base.peer_name);
+		if (hostlen > 255) {
+			belle_sip_error("SOCKS5 proxy connect failed: peer hostname [%s] is too long", obj->base.peer_name);
+			return -1;
+		}
+		request[0] = 0x05; /* SOCKS version */
+		request[1] = 0x01; /* CONNECT */
+		request[2] = 0x00; /* reserved */
+		request[3] = 0x03; /* domain name */
+		request[4] = (unsigned char)hostlen;
+		memcpy(request + 5, obj->base.peer_name, hostlen);
+		request[5 + hostlen] = (unsigned char)((obj->base.peer_port >> 8) & 0xff);
+		request[6 + hostlen] = (unsigned char)(obj->base.peer_port & 0xff);
+		request_len = 7 + hostlen;
+		ret = stream_channel_send(obj, request, request_len);
+		if (ret != (int)request_len) return -1;
+		obj->socks5_proxy_waiting_for_connect_response = 2;
+		obj->socks5_proxy_response_len = 0;
+		return 1;
+	}
+	ret = socks5_recv_until(obj, 5);
+	if (ret != 0) return ret;
+	atyp = obj->socks5_proxy_response[3];
+	if (atyp == 0x01) expected_len = 10;
+	else if (atyp == 0x03) expected_len = 5 + obj->socks5_proxy_response[4] + 2;
+	else if (atyp == 0x04) expected_len = 22;
+	else {
+		belle_sip_error("SOCKS5 proxy [%s:%i] returned unsupported address type [%i]",
+		                obj->base.stack->socks5_proxy_host, socks5_proxy_port(obj->base.stack), atyp);
+		return -1;
+	}
+	ret = socks5_recv_until(obj, expected_len);
+	if (ret != 0) return ret;
+	if (obj->socks5_proxy_response[0] != 0x05 || obj->socks5_proxy_response[1] != 0x00) {
+		belle_sip_error("SOCKS5 proxy [%s:%i] rejected CONNECT to [%s:%i] with status [%i]",
+		                obj->base.stack->socks5_proxy_host, socks5_proxy_port(obj->base.stack), obj->base.peer_name,
+		                obj->base.peer_port, obj->socks5_proxy_response[1]);
+		return -1;
+	}
+	obj->socks5_proxy_connected = TRUE;
+	obj->socks5_proxy_waiting_for_connect_response = 0;
+	return 0;
+}
+
+int stream_channel_connect_to(belle_sip_stream_channel_t *obj, const struct addrinfo *ai) {
 	int err;
 	int tmp;
 	belle_sip_socket_t sock;
@@ -182,6 +272,37 @@ int stream_channel_connect(belle_sip_stream_channel_t *obj, const struct addrinf
 	                                   belle_sip_stack_get_transport_timeout(obj->base.stack));
 	belle_sip_main_loop_add_source(obj->base.stack->ml, (belle_sip_source_t *)obj);
 	return 0;
+}
+
+static void socks5_proxy_res_done(void *data, belle_sip_resolver_results_t *results) {
+	belle_sip_stream_channel_t *obj = (belle_sip_stream_channel_t *)data;
+	const struct addrinfo *ai_list;
+	if (obj->socks5_proxy_resolver_ctx) {
+		belle_sip_object_unref(obj->socks5_proxy_resolver_ctx);
+		obj->socks5_proxy_resolver_ctx = NULL;
+	}
+	ai_list = belle_sip_resolver_results_get_addrinfos(results);
+	if (ai_list) {
+		stream_channel_connect_to(obj, ai_list);
+	} else {
+		belle_sip_error("%s: DNS resolution failed for SOCKS5 proxy %s", __FUNCTION__,
+		                belle_sip_resolver_results_get_name(results));
+		channel_set_state((belle_sip_channel_t *)obj, BELLE_SIP_CHANNEL_ERROR);
+	}
+}
+
+int stream_channel_connect(belle_sip_stream_channel_t *obj, const struct addrinfo *ai) {
+	belle_sip_stack_t *stack = obj->base.stack;
+
+	if (stream_channel_socks5_proxy_enabled(obj)) {
+		belle_sip_message("Resolving SOCKS5 proxy addr [%s] for channel [%p]", stack->socks5_proxy_host, obj);
+		obj->socks5_proxy_resolver_ctx =
+		    belle_sip_stack_resolve_a(stack, stack->socks5_proxy_host, socks5_proxy_port(stack), ai->ai_family,
+		                              socks5_proxy_res_done, obj);
+		if (obj->socks5_proxy_resolver_ctx) belle_sip_object_ref(obj->socks5_proxy_resolver_ctx);
+		return 0;
+	}
+	return stream_channel_connect_to(obj, ai);
 }
 
 BELLE_SIP_DECLARE_NO_IMPLEMENTED_INTERFACES(belle_sip_stream_channel_t);
@@ -253,6 +374,24 @@ static int stream_channel_process_data(belle_sip_stream_channel_t *obj, unsigned
 	/*belle_sip_message("TCP channel process_data");*/
 
 	if (state == BELLE_SIP_CHANNEL_CONNECTING) {
+		if (obj->socks5_proxy_waiting_for_connect_response) {
+			int socks_ret = stream_channel_process_socks5_response(obj);
+			if (socks_ret == -1) {
+				channel_set_state(base, BELLE_SIP_CHANNEL_ERROR);
+				return BELLE_SIP_STOP;
+			}
+			if (socks_ret == 1) return BELLE_SIP_CONTINUE;
+			if (bctbx_getsockname(belle_sip_source_get_socket((belle_sip_source_t *)obj), (struct sockaddr *)&ss,
+			                      &addrlen) == -1) {
+				belle_sip_error("Failed to retrieve sockname for SOCKS5 proxied channel [%p]: %s", obj,
+				                belle_sip_get_socket_error_string());
+				channel_set_state(base, BELLE_SIP_CHANNEL_ERROR);
+				return BELLE_SIP_STOP;
+			}
+			belle_sip_source_set_timeout_int64((belle_sip_source_t *)obj, -1);
+			belle_sip_channel_set_ready(base, (struct sockaddr *)&ss, addrlen);
+			return BELLE_SIP_CONTINUE;
+		}
 		if (finalize_stream_connection(obj, revents, (struct sockaddr *)&ss, &addrlen)) {
 			belle_sip_error("Cannot connect to [%s://%s:%i]", belle_sip_channel_get_transport_name(base),
 			                base->peer_name, base->peer_port);
@@ -260,6 +399,13 @@ static int stream_channel_process_data(belle_sip_stream_channel_t *obj, unsigned
 			return BELLE_SIP_STOP;
 		}
 		belle_sip_source_set_events((belle_sip_source_t *)obj, BELLE_SIP_EVENT_READ | BELLE_SIP_EVENT_ERROR);
+		if (stream_channel_socks5_proxy_enabled(obj) && !obj->socks5_proxy_connected) {
+			if (stream_channel_start_socks5_connect(obj) == -1) {
+				channel_set_state(base, BELLE_SIP_CHANNEL_ERROR);
+				return BELLE_SIP_STOP;
+			}
+			return BELLE_SIP_CONTINUE;
+		}
 		belle_sip_source_set_timeout_int64((belle_sip_source_t *)obj, -1);
 		belle_sip_channel_set_ready(base, (struct sockaddr *)&ss, addrlen);
 		return BELLE_SIP_CONTINUE;

--- a/belle-sip/src/transports/stream_channel.h
+++ b/belle-sip/src/transports/stream_channel.h
@@ -32,6 +32,11 @@
 
 struct belle_sip_stream_channel {
 	belle_sip_channel_t base;
+	belle_sip_resolver_context_t *socks5_proxy_resolver_ctx;
+	int socks5_proxy_connected;
+	int socks5_proxy_waiting_for_connect_response;
+	unsigned char socks5_proxy_response[262];
+	size_t socks5_proxy_response_len;
 #if TARGET_OS_IPHONE
 	CFReadStreamRef read_stream;
 	CFWriteStreamRef write_stream;
@@ -64,11 +69,15 @@ belle_sip_channel_t *belle_sip_stream_channel_new_child(belle_sip_stack_t *stack
 
 void stream_channel_close(belle_sip_stream_channel_t *obj);
 int stream_channel_connect(belle_sip_stream_channel_t *obj, const struct addrinfo *ai);
+int stream_channel_connect_to(belle_sip_stream_channel_t *obj, const struct addrinfo *ai);
 /*return 0 if succeed*/
 int finalize_stream_connection(belle_sip_stream_channel_t *obj,
                                unsigned int revents,
                                struct sockaddr *addr,
                                socklen_t *slen);
+int stream_channel_socks5_proxy_enabled(const belle_sip_stream_channel_t *obj);
+int stream_channel_start_socks5_connect(belle_sip_stream_channel_t *obj);
+int stream_channel_process_socks5_response(belle_sip_stream_channel_t *obj);
 int stream_channel_send(belle_sip_stream_channel_t *obj, const void *buf, size_t buflen);
 int stream_channel_recv(belle_sip_stream_channel_t *obj, void *buf, size_t buflen);
 

--- a/belle-sip/src/transports/tls_channel.c
+++ b/belle-sip/src/transports/tls_channel.c
@@ -437,7 +437,7 @@ static int tls_channel_connect_to(belle_sip_channel_t *obj, const struct addrinf
 
 	if (belle_sip_tls_channel_init_bctbx_ssl((belle_sip_tls_channel_t *)obj) == -1) return -1;
 
-	err = stream_channel_connect((belle_sip_stream_channel_t *)obj, ai);
+	err = stream_channel_connect_to((belle_sip_stream_channel_t *)obj, ai);
 	if (err == 0) {
 		belle_sip_source_set_notify((belle_sip_source_t *)obj, (belle_sip_source_func_t)tls_process_data);
 		return 0;
@@ -461,9 +461,39 @@ static void http_proxy_res_done(void *data, belle_sip_resolver_results_t *result
 	}
 }
 
+static int tls_socks5_proxy_port(const belle_sip_stack_t *stack) {
+	return stack->socks5_proxy_port > 0 ? stack->socks5_proxy_port : 1080;
+}
+
+static void socks5_proxy_res_done(void *data, belle_sip_resolver_results_t *results) {
+	belle_sip_tls_channel_t *obj = (belle_sip_tls_channel_t *)data;
+	belle_sip_stream_channel_t *stream = (belle_sip_stream_channel_t *)obj;
+	const struct addrinfo *ai_list;
+	if (stream->socks5_proxy_resolver_ctx) {
+		belle_sip_object_unref(stream->socks5_proxy_resolver_ctx);
+		stream->socks5_proxy_resolver_ctx = NULL;
+	}
+	ai_list = belle_sip_resolver_results_get_addrinfos(results);
+	if (ai_list) {
+		tls_channel_connect_to((belle_sip_channel_t *)obj, ai_list);
+	} else {
+		belle_sip_error("%s: DNS resolution failed for SOCKS5 proxy %s", __FUNCTION__,
+		                belle_sip_resolver_results_get_name(results));
+		channel_set_state((belle_sip_channel_t *)obj, BELLE_SIP_CHANNEL_ERROR);
+	}
+}
+
 static int tls_channel_connect(belle_sip_channel_t *obj, const struct addrinfo *ai) {
 	belle_sip_tls_channel_t *channel = (belle_sip_tls_channel_t *)obj;
-	if (obj->stack->http_proxy_host) {
+	if (stream_channel_socks5_proxy_enabled((belle_sip_stream_channel_t *)obj)) {
+		belle_sip_stream_channel_t *stream = (belle_sip_stream_channel_t *)obj;
+		belle_sip_message("Resolving SOCKS5 proxy addr [%s] for channel [%p]", obj->stack->socks5_proxy_host, obj);
+		stream->socks5_proxy_resolver_ctx =
+		    belle_sip_stack_resolve_a(obj->stack, obj->stack->socks5_proxy_host, tls_socks5_proxy_port(obj->stack),
+		                              ai->ai_family, socks5_proxy_res_done, obj);
+		if (stream->socks5_proxy_resolver_ctx) belle_sip_object_ref(stream->socks5_proxy_resolver_ctx);
+		return 0;
+	} else if (obj->stack->http_proxy_host) {
 		belle_sip_message("Resolving http proxy addr [%s] for channel [%p]", obj->stack->http_proxy_host, obj);
 		/*assume ai family is the same*/
 		channel->http_proxy_resolver_ctx =
@@ -600,6 +630,7 @@ static int tls_process_data(belle_sip_channel_t *obj, unsigned int revents) {
 	int err;
 
 	if (obj->state == BELLE_SIP_CHANNEL_CONNECTING) {
+		belle_sip_stream_channel_t *stream = (belle_sip_stream_channel_t *)obj;
 		if (!channel->socket_connected) {
 			channel->socklen = sizeof(channel->ss);
 			if (finalize_stream_connection((belle_sip_stream_channel_t *)obj, revents, (struct sockaddr *)&channel->ss,
@@ -611,12 +642,23 @@ static int tls_process_data(belle_sip_channel_t *obj, unsigned int revents) {
 			belle_sip_source_set_events((belle_sip_source_t *)channel, BELLE_SIP_EVENT_READ | BELLE_SIP_EVENT_ERROR);
 			belle_sip_source_set_timeout_int64((belle_sip_source_t *)obj,
 			                                   belle_sip_stack_get_transport_timeout(obj->stack));
-			if (obj->stack->http_proxy_host) {
+			if (stream_channel_socks5_proxy_enabled(stream)) {
+				belle_sip_message("Channel [%p]: Connected at TCP level, now doing SOCKS5 proxy connect", obj);
+				if (stream_channel_start_socks5_connect(stream) == -1) goto process_error;
+			} else if (obj->stack->http_proxy_host) {
 				belle_sip_message("Channel [%p]: Connected at TCP level, now doing http proxy connect", obj);
 				if (tls_process_http_connect(channel)) goto process_error;
 			} else {
 				belle_sip_message("Channel [%p]: Connected at TCP level, now doing TLS handshake with cname=%s", obj,
 				                  obj->peer_cname ? obj->peer_cname : obj->peer_name);
+				if (tls_process_handshake(obj) == -1) goto process_error;
+			}
+		} else if (stream_channel_socks5_proxy_enabled(stream) && !stream->socks5_proxy_connected) {
+			err = stream_channel_process_socks5_response(stream);
+			if (err == -1) goto process_error;
+			if (err == 0) {
+				belle_sip_message("Channel [%p]: connected to SOCKS5 proxy, doing TLS handshake [%s:%i]", channel,
+				                  obj->stack->socks5_proxy_host, tls_socks5_proxy_port(obj->stack));
 				if (tls_process_handshake(obj) == -1) goto process_error;
 			}
 		} else if (obj->stack->http_proxy_host && !channel->http_proxy_connected) {

--- a/liblinphone/coreapi/help/doc/doxygen/provisioning_configuration_key.dox.in
+++ b/liblinphone/coreapi/help/doc/doxygen/provisioning_configuration_key.dox.in
@@ -33,6 +33,8 @@ The <i>sip</i> section represents a general configuration for SIP.
 	<tr><td>guess_hostname</td><td>integer</td><td>0 or 1</td><td>1</td><td>linphone_core_set_guess_hostname()</td><td>\copybrief linphone_core_set_guess_hostname</td></tr>
 	<tr><td>http_proxy_host</td><td>string</td><td>a hostname</td><td>""</td><td>linphone_core_set_http_proxy_host()</td><td>\copybrief linphone_core_set_http_proxy_host</td></tr>
 	<tr><td>http_proxy_port</td><td>integer</td><td>0 - 65535</td><td>3128</td><td>linphone_core_set_http_proxy_port()</td><td>\copybrief linphone_core_set_http_proxy_port</td></tr>
+	<tr><td>socks5_proxy_host</td><td>string</td><td>a hostname</td><td>""</td><td>linphone_core_set_socks5_proxy_host()</td><td>\copybrief linphone_core_set_socks5_proxy_host</td></tr>
+	<tr><td>socks5_proxy_port</td><td>integer</td><td>0 - 65535</td><td>1080</td><td>linphone_core_set_socks5_proxy_port()</td><td>\copybrief linphone_core_set_socks5_proxy_port</td></tr>
 	<tr><td>ice_enabled</td><td>integer</td><td>0 or 1</td><td>1</td><td>linphone_nat_policy_ice_enabled()</td><td>\copybrief linphone_nat_policy_ice_enabled</td></tr>
 	<tr><td>in_call_timeout</td><td>integer</td><td>0–86400 (s)</td><td>0</td><td>linphone_core_set_in_call_timeout()</td><td>\copybrief linphone_core_set_in_call_timeout</td></tr>
 	<tr><td>inc_timeout</td><td>integer</td><td>0–300 (s)</td><td>Android and IOS: 45. Else: 30</td><td>linphone_core_set_inc_timeout()</td><td>\copybrief linphone_core_set_inc_timeout</td></tr>

--- a/liblinphone/coreapi/linphonecore.c
+++ b/liblinphone/coreapi/linphonecore.c
@@ -3403,6 +3403,8 @@ static void linphone_core_init(LinphoneCore *lc,
 	lc->sal->setRefresherRetryAfter(linphone_config_get_int(lc->config, "sip", "refresher_retry_after", 60000));
 	lc->sal->setHttpProxyHost(L_C_TO_STRING(linphone_core_get_http_proxy_host(lc)));
 	lc->sal->setHttpProxyPort(linphone_core_get_http_proxy_port(lc));
+	lc->sal->setSocks5ProxyHost(L_C_TO_STRING(linphone_core_get_socks5_proxy_host(lc)));
+	lc->sal->setSocks5ProxyPort(linphone_core_get_socks5_proxy_port(lc));
 
 	lc->sal->setUserPointer(lc);
 	lc->sal->setCallbacks(&linphone_sal_callbacks);
@@ -4337,6 +4339,10 @@ int _linphone_core_apply_transports(LinphoneCore *lc) {
 	if (linphone_core_get_http_proxy_host(lc)) {
 		sal->setHttpProxyHost(linphone_core_get_http_proxy_host(lc));
 		sal->setHttpProxyPort(linphone_core_get_http_proxy_port(lc));
+	}
+	if (linphone_core_get_socks5_proxy_host(lc)) {
+		sal->setSocks5ProxyHost(linphone_core_get_socks5_proxy_host(lc));
+		sal->setSocks5ProxyPort(linphone_core_get_socks5_proxy_port(lc));
 	}
 	if (lc->tunnel && linphone_tunnel_sip_enabled(lc->tunnel) && linphone_tunnel_get_activated(lc->tunnel)) {
 		sal->setListenPort(anyaddr, tr->udp_port, SalTransportUDP, TRUE);
@@ -9241,6 +9247,29 @@ const char *linphone_core_get_http_proxy_host(const LinphoneCore *lc) {
 
 int linphone_core_get_http_proxy_port(const LinphoneCore *lc) {
 	return linphone_config_get_int(lc->config, "sip", "http_proxy_port", 3128);
+}
+
+void linphone_core_set_socks5_proxy_host(LinphoneCore *lc, const char *host) {
+	CoreLogContextualizer logContextualizer(lc);
+	linphone_config_set_string(lc->config, "sip", "socks5_proxy_host", host);
+	if (lc->sal) {
+		lc->sal->setSocks5ProxyHost(L_C_TO_STRING(host));
+		lc->sal->setSocks5ProxyPort(linphone_core_get_socks5_proxy_port(lc));
+	}
+}
+
+void linphone_core_set_socks5_proxy_port(LinphoneCore *lc, int port) {
+	CoreLogContextualizer logContextualizer(lc);
+	linphone_config_set_int(lc->config, "sip", "socks5_proxy_port", port);
+	if (lc->sal) lc->sal->setSocks5ProxyPort(port);
+}
+
+const char *linphone_core_get_socks5_proxy_host(const LinphoneCore *lc) {
+	return linphone_config_get_string(lc->config, "sip", "socks5_proxy_host", NULL);
+}
+
+int linphone_core_get_socks5_proxy_port(const LinphoneCore *lc) {
+	return linphone_config_get_int(lc->config, "sip", "socks5_proxy_port", 1080);
 }
 
 const char *linphone_transport_to_string(LinphoneTransportType transport) {

--- a/liblinphone/include/linphone/core.h
+++ b/liblinphone/include/linphone/core.h
@@ -6186,6 +6186,39 @@ LINPHONE_PUBLIC const char *linphone_core_get_http_proxy_host(const LinphoneCore
  */
 LINPHONE_PUBLIC int linphone_core_get_http_proxy_port(const LinphoneCore *core);
 
+/**
+ * Sets SOCKS5 proxy address to be used for TCP-based signaling during next channel connection. Use
+ * #linphone_core_set_network_reachable() FALSE/TRUE to force channel restart.
+ * @param core #LinphoneCore object @notnil
+ * @param host Hostname or IP address of the SOCKS5 proxy (can be NULL to disable). @maybenil
+ * @ingroup group_network_parameters
+ */
+LINPHONE_PUBLIC void linphone_core_set_socks5_proxy_host(LinphoneCore *core, const char *host);
+
+/**
+ * Sets SOCKS5 proxy port to be used for TCP-based signaling.
+ * @param core #LinphoneCore object @notnil
+ * @param port of the SOCKS5 proxy.
+ * @ingroup group_network_parameters
+ */
+LINPHONE_PUBLIC void linphone_core_set_socks5_proxy_port(LinphoneCore *core, int port);
+
+/**
+ * Gets SOCKS5 proxy address to be used for TCP-based signaling.
+ * @param core #LinphoneCore object @notnil
+ * @return hostname or IP address of the SOCKS5 proxy (can be NULL to disable). @maybenil
+ * @ingroup group_network_parameters
+ */
+LINPHONE_PUBLIC const char *linphone_core_get_socks5_proxy_host(const LinphoneCore *core);
+
+/**
+ * Gets SOCKS5 proxy port to be used for TCP-based signaling.
+ * @param core #LinphoneCore object @notnil
+ * @return port of the SOCKS5 proxy.
+ * @ingroup group_network_parameters
+ */
+LINPHONE_PUBLIC int linphone_core_get_socks5_proxy_port(const LinphoneCore *core);
+
 LINPHONE_PUBLIC LinphoneRingtonePlayer *linphone_core_get_ringtoneplayer(LinphoneCore *core);
 
 /**

--- a/liblinphone/src/sal/sal.cpp
+++ b/liblinphone/src/sal/sal.cpp
@@ -738,6 +738,15 @@ const string &Sal::getHttpProxyHost() const {
 	return mHttpProxyHost;
 }
 
+void Sal::setSocks5ProxyHost(const string &value) {
+	belle_sip_stack_set_socks5_proxy_host(mStack, L_STRING_TO_C(value));
+}
+
+const string &Sal::getSocks5ProxyHost() const {
+	mSocks5ProxyHost = L_C_TO_STRING(belle_sip_stack_get_socks5_proxy_host(mStack));
+	return mSocks5ProxyHost;
+}
+
 bool Sal::isContentEncodingAvailable(const string &contentEncoding) const {
 	return !!belle_sip_stack_content_encoding_available(mStack, L_STRING_TO_C(contentEncoding));
 }

--- a/liblinphone/src/sal/sal.h
+++ b/liblinphone/src/sal/sal.h
@@ -360,6 +360,15 @@ public:
 	int getHttpProxyPort() const {
 		return belle_sip_stack_get_http_proxy_port(mStack);
 	}
+	void setSocks5ProxyHost(const std::string &value);
+	const std::string &getSocks5ProxyHost() const;
+
+	void setSocks5ProxyPort(int value) {
+		belle_sip_stack_set_socks5_proxy_port(mStack, value);
+	}
+	int getSocks5ProxyPort() const {
+		return belle_sip_stack_get_socks5_proxy_port(mStack);
+	}
 
 	void unlistenPorts();
 	void resetTransports();
@@ -535,6 +544,7 @@ private:
 	// Cache values
 	mutable std::string mDnsUserHostsFile;
 	mutable std::string mHttpProxyHost;
+	mutable std::string mSocks5ProxyHost;
 	mutable std::string mSupported;
 	mutable std::string mUserAgent;
 


### PR DESCRIPTION
Summary:
- Add Core API and provisioning keys for SOCKS5 proxy host/port.
- Propagate SOCKS5 proxy settings through SAL into the belle-sip stack.
- Route TCP and TLS SIP channels through an unauthenticated SOCKS5 CONNECT handshake before the normal SIP/TLS flow, without changing the existing HTTP proxy path.

Validation:
- `git diff --check`
- `cc -fsyntax-only -DPACKAGE_VERSION=\"5.99.0\" -I belle-sip/include -I belle-sip/src -I bctoolbox/include -I belr/include belle-sip/src/transports/stream_channel.c`
- `cc -fsyntax-only -DPACKAGE_VERSION=\"5.99.0\" -I belle-sip/include -I belle-sip/src -I bctoolbox/include -I belr/include belle-sip/src/transports/tls_channel.c`
- Local SOCKS5 wire smoke validating the no-auth greeting and domain-name CONNECT request for `sip.example.org:5061`.