### PR TITLE
fix(sdp): rtcp-xr max-size greedily consumes following xr-format tokens (stat-summary / voip-metrics dropped)

### DIFF
--- a/belle-sip/src/sdp/sdp.txt
+++ b/belle-sip/src/sdp/sdp.txt
@@ -399,7 +399,7 @@ stat-flag      = "loss"
                 / "TTL"
                 / "HL"
 voip-metrics   = "voip-metrics"
-max-size       = text; 1*DIGIT ; maximum block size in octets
+max-size       = 1*DIGIT ; maximum block size in octets
 ;DIGIT         = %x30-39
 format-ext     = text; non-ws-string
 


### PR DESCRIPTION
## Summary
The SDP `a=rtcp-xr` parser silently drops the `stat-summary` and `voip-metrics`
tokens whenever they follow an `rcvr-rtt=<mode>:<max-size>` token (and more
generally any `…=<max-size>` token). Root cause: the `max-size` ABNF rule is
defined as `text`, which matches any byte except NUL/CR/LF — **including
spaces** — so it greedily consumes the rest of the attribute line.

## Root cause
In `belle-sip/src/sdp/sdp.txt`:
rcvr-rtt = "rcvr-rtt" "=" rcvr-rtt-mode [":" max-size]
max-size = text        ; text = byte-string = 1*(%x01-09/%x0B-0C/%x0E-FF) → includes SP
Parsing:
a=rtcp-xr:rcvr-rtt=all:10000 stat-summary=loss,dup,jitt,TTL voip-metrics
`max-size` matches `10000 stat-summary=loss,dup,jitt,TTL voip-metrics` (up to
CR/LF) instead of just `10000`. The `*(SP xr-format)` repetition then has
nothing left to match, so `belle_sdp_rtcp_xr_attribute_has_stat_summary()` and
`belle_sdp_rtcp_xr_attribute_has_voip_metrics()` return false.

## Impact
Downstream (ortp/liblinphone), for a `sendrecv` stream the RTCP-XR session
configuration is taken from the remote description. With `voip_metrics_enabled`
parsed as false, the endpoint never emits the RTCP-XR VoIP Metrics block, and
RFC 6035 (vq-rtcpxr) quality reports are missing `PacketLoss`, `JitterBuffer`
and remote MOS. Because linphone generates the attribute with `rcvr-rtt` first,
the issue is self-inflicted on any linphone↔linphone call.

## Fix
Define `max-size` as `1*DIGIT` (its documented meaning: "maximum block size in
octets"). It then stops at the first non-digit and the following `stat-summary`
/ `voip-metrics` tokens parse correctly. One-line change.

## Verification
With `belr-parse <grammar> <attr> rtcp-xr-attribute rcvr-rtt max-size stat-summary voip-metrics`:

- **Before:** `max-size : '10000 stat-summary=loss,dup,jitt,TTL voip-metrics'`
  (`stat-summary` and `voip-metrics` never matched)
- **After:** `max-size : '10000'`, then `stat-summary` (with its flags) and
  `voip-metrics` matched.

Confirmed end-to-end: after the fix the endpoint emits RTCP-XR VoIP Metrics and
the vq-rtcpxr reports contain `PacketLoss` / `JitterBuffer` again.

## ⚠️ Grammar recompilation required
The runtime loads the precompiled grammar `belle-sip/src/sdp/sdp_grammar.belr`
(via `GrammarLoader`), not `sdp.txt`. This MR intentionally updates **only** the
ABNF source. For the fix to take effect at runtime, `sdp_grammar.belr` must be
regenerated in-house (e.g. `belr-compiler belle-sip/src/sdp/sdp.txt
belle-sip/src/sdp/sdp_grammar.belr`) and committed alongside this change.