### PR TITLE
Fix quality reporting sending the video report twice and never the text report

### DIFF
--- a/liblinphone/coreapi/quality_reporting.c
+++ b/liblinphone/coreapi/quality_reporting.c
@@ -745,9 +745,9 @@ static int publish_report(LinphoneCall *call, const char *event_type) {
 	for (const auto &idx :
 	     {_linphone_call_get_main_audio_stream_index(call), _linphone_call_get_main_video_stream_index(call),
 	      _linphone_call_get_main_text_stream_index(call)}) {
-		int stream_index = idx == _linphone_call_get_main_audio_stream_index(call) ? LINPHONE_CALL_STATS_AUDIO
-		                   : _linphone_call_get_main_video_stream_index(call)      ? LINPHONE_CALL_STATS_VIDEO
-		                                                                           : LINPHONE_CALL_STATS_TEXT;
+		int stream_index = idx == _linphone_call_get_main_audio_stream_index(call)   ? LINPHONE_CALL_STATS_AUDIO
+		                   : idx == _linphone_call_get_main_video_stream_index(call) ? LINPHONE_CALL_STATS_VIDEO
+		                                                                             : LINPHONE_CALL_STATS_TEXT;
 		if (media_report_enabled(call, stream_index)) {
 			int sndret;
 			linphone_reporting_update_media_info(call, stream_index);


### PR DESCRIPTION
### Problem

At call termination (and for every interval report), `publish_report()` in
`liblinphone/coreapi/quality_reporting.c` publishes the video
`VQSessionReport` **twice** and never publishes the text report.

Observed on a real audio+video call: three `PUBLISH sip:… vq-rtcpxr` are sent
— one audio report, then the **same** video report twice (identical SSRC). The
second copy is missing its averaged metrics (`JBN`, `JBM`, `RTD`, `MOSLQ/MOSCQ`)
because `reset_avg_metrics()` already ran after the first send.

### Root cause

The loop iterates over the audio, video and text stream indices and maps each
index back to a stats type. The middle branch of the ternary tested the video
stream index for *truthiness* instead of comparing it to the current index:

```c
int stream_index = idx == _linphone_call_get_main_audio_stream_index(call) ? LINPHONE_CALL_STATS_AUDIO
                   : _linphone_call_get_main_video_stream_index(call)      ? LINPHONE_CALL_STATS_VIDEO
                                                                           : LINPHONE_CALL_STATS_TEXT;
```

`_linphone_call_get_main_video_stream_index(call)` is a fixed, non-zero value
whenever video exists, so it is always truthy. The text-index iteration
therefore fell into the VIDEO branch → the video report was sent a second
time and the text report was never sent.

### Fix

Compare the loop index against the video stream index, so each index maps to
its own stats type:

```c
int stream_index = idx == _linphone_call_get_main_audio_stream_index(call)   ? LINPHONE_CALL_STATS_AUDIO
                   : idx == _linphone_call_get_main_video_stream_index(call) ? LINPHONE_CALL_STATS_VIDEO
                                                                             : LINPHONE_CALL_STATS_TEXT;
```

Disabled/absent streams are still skipped by media_report_enabled().

### Result

After the fix, a call terminates with exactly one report per active stream:
one audio, one video (with all its metrics), and one text report only when
real-time text is enabled.