### PR TITLE
Fix incomplete quality report published on media renegotiation

### DIFF
--- a/liblinphone/coreapi/quality_reporting.c
+++ b/liblinphone/coreapi/quality_reporting.c
@@ -809,6 +809,10 @@ void linphone_reporting_call_state_updated(LinphoneCall *call) {
 			linphone_reporting_update_ip(call);
 			if (media_report_enabled(call, LINPHONE_CALL_STATS_VIDEO) &&
 			    log->getQualityReporting()->was_video_running) {
+				// Populate the report before sending it (call id, addresses, timestamps, session description...).
+				// Without this the "media changed" video report is published with null identifiers and no
+				// timestamps, unlike every other send_report path which goes through update_media_info first.
+				linphone_reporting_update_media_info(call, LINPHONE_CALL_STATS_VIDEO);
 				send_report(call, log->getQualityReporting()->reports[LINPHONE_CALL_STATS_VIDEO], "VQSessionReport");
 			}
 			log->getQualityReporting()->was_video_running =


### PR DESCRIPTION
### Problem

When the media is renegotiated during a call while video is running (e.g. a
re-INVITE that changes the video stream), a **partially-filled**
`VQSessionReport` is published mid-call. Observed report:

VQSessionReport
CallID: (null)
LocalID: (null)
RemoteID: (null)
OrigID: (null)
LocalAddr: IP=... PORT=... SSRC=0
RemoteAddr: IP=... PORT=... SSRC=0
LocalMetrics:
Timestamps:
JitterBuffer: JBA=3 JBN=60 JBM=46 JBX=65535
PacketLoss: NLR=0.0 JDR=0.0
Delay: RTD=0
...

The identifiers are null, there are no timestamps and `SSRC=0`, even though
the metrics filled continuously from RTCP are present.

### Root cause

On the `LinphoneCallStreamsRunning` transition,
`linphone_reporting_call_state_updated()` publishes a video `VQSessionReport`
when `was_video_running` is set (RFC 6035 "media changed" report). Unlike every
other `send_report()` path — the interval report and `publish_report()` — this
one does **not** call `linphone_reporting_update_media_info()` first. That
function is what fills the mandatory fields (call id, local/remote/orig ids,
addresses, SSRC, timestamps, session description), hence the null/empty report.

### Fix

Call `linphone_reporting_update_media_info(call, LINPHONE_CALL_STATS_VIDEO)`
before `send_report()`, consistent with all the other publishing paths.

```c
if (media_report_enabled(call, LINPHONE_CALL_STATS_VIDEO) &&
    log->getQualityReporting()->was_video_running) {
    linphone_reporting_update_media_info(call, LINPHONE_CALL_STATS_VIDEO);
    send_report(call, ...reports[LINPHONE_CALL_STATS_VIDEO], "VQSessionReport")
}
```

### Result

The media-change report is now published complete (identifiers, timestamps,
SSRC, session description), like the interval and CallTerm reports.