### PR TITLE
Fix crash when resolving macOS plugin path

### DIFF
--- a/liblinphone/src/core/platform-helpers/mac-platform-helpers.mm
+++ b/liblinphone/src/core/platform-helpers/mac-platform-helpers.mm
@@ -132,7 +132,7 @@ string MacPlatformHelpers::getBundleResourceDirPath(const string &framework, con
 		if (bundleUrl) {
 			CFURLRef resourceUrl = CFURLCreateCopyAppendingPathComponent(NULL, bundleUrl, cfResource, true);
 			CFStringRef cfSystemPath = CFURLCopyFileSystemPath(resourceUrl, kCFURLPOSIXPathStyle);
-			path = CFStringGetCStringPtr(cfSystemPath, encodingMethod);
+			path = toString(cfSystemPath, encodingMethod);
 			CFRelease(cfSystemPath);
 			CFRelease(bundleUrl);
 			CFRelease(resourceUrl);


### PR DESCRIPTION
## What changed

Use the existing `MacPlatformHelpers::toString()` helper when converting the macOS plugin resource path instead of assigning the result of `CFStringGetCStringPtr()` directly to `std::string`.

## Why

`CFStringGetCStringPtr()` is allowed to return `NULL` when Core Foundation cannot expose a direct pointer for the requested encoding. Passing that result to `std::string` causes a null-pointer crash while the core initializes its plugins:

```
_platform_strlen
std::string::__assign_external
MacPlatformHelpers::getBundleResourceDirPath
MacPlatformHelpers::getPluginsDir
LinphonePrivate::Core::initPlugins
```

This was reproduced on macOS 26.5.2 with the Japanese system text encoding (`CFStringGetSystemEncoding() == 1`). For the generated framework path, `CFStringGetCStringPtr()` returned `NULL`, while `CFStringGetCString()` completed successfully.

The same file already uses `toString()` for resource-path conversion. That helper handles a null `CFStringRef` and copies the value through `CFStringGetCString()`.

## Impact

Prevents Linphone from crashing during startup on macOS configurations where Core Foundation does not provide a direct C-string pointer for the framework path.

## Validation

- `git diff --check`
- Standalone Core Foundation reproducer on macOS 26.5.2: direct pointer was `NULL`; safe conversion succeeded
- Confirmed the change is limited to the plugin-path conversion in `mac-platform-helpers.mm`

Full Linphone SDK compilation was not run locally.
