### PR TITLE
av1: implemented full depaketization

### DIFF
--- a/mediastreamer2/src/videofilters/av1/obu/obu-unpacker.cpp
+++ b/mediastreamer2/src/videofilters/av1/obu/obu-unpacker.cpp
@@ -20,19 +20,62 @@
 
 #include "obu-unpacker.h"
 
-#include <stdexcept>
-
 using namespace std;
 
 namespace mediastreamer {
 
+namespace {
+
+constexpr uint8_t kObuTypeTemporalDelimiter = 2;
+
+// leb128 as defined by AV1 §4.10.5: at most 8 bytes.
+bool readLeb128(const uint8_t *data, size_t size, uint64_t &value, size_t &length) {
+	value = 0;
+	for (size_t i = 0; i < 8 && i < size; i++) {
+		value |= (uint64_t)(data[i] & 0x7f) << (i * 7);
+		if ((data[i] & 0x80) == 0) {
+			length = i + 1;
+			return true;
+		}
+	}
+	return false;
+}
+
+size_t writeLeb128(uint8_t *out, uint64_t value) {
+	size_t length = 0;
+	do {
+		out[length] = value & 0x7f;
+		value >>= 7;
+		if (value) out[length] |= 0x80;
+		length++;
+	} while (value);
+	return length;
+}
+
+} // namespace
+
 ObuUnpacker::~ObuUnpacker() {
 	if (mFrame) freemsg(mFrame);
+	if (mPendingFragment) freemsg(mPendingFragment);
+}
+
+void ObuUnpacker::reset() {
+	discardFrame();
+	mInitializedRefCSeq = false;
+}
+
+void ObuUnpacker::discardFrame() {
+	if (mFrame) freemsg(mFrame);
+	mFrame = nullptr;
+	if (mPendingFragment) freemsg(mPendingFragment);
+	mPendingFragment = nullptr;
+	mFrameCorrupted = false;
 }
 
 ObuUnpacker::Status ObuUnpacker::unpack(mblk_t *im, MSQueue *output) {
 	uint16_t cseq = mblk_get_cseq(im);
-	Status ret = NoFrame;
+	bool marker = mblk_get_marker_info(im) != 0;
+	bool wasCorrupted = mFrameCorrupted;
 
 	if (im->b_cont) msgpullup(im, -1);
 
@@ -44,71 +87,180 @@ ObuUnpacker::Status ObuUnpacker::unpack(mblk_t *im, MSQueue *output) {
 		if (mRefCSeq != cseq) {
 			ms_message("ObuUnpacker: Sequence inconsistency detected (diff=%i)", (int)(cseq - mRefCSeq));
 			mRefCSeq = cseq;
-			ret = FrameCorrupted;
+			// Packets are missing: neither the OBU under reassembly nor the
+			// current temporal unit can be completed.
+			if (mPendingFragment) {
+				freemsg(mPendingFragment);
+				mPendingFragment = nullptr;
+			}
+			mFrameCorrupted = true;
 		}
 	}
 
-	mblk_t *om = feed(im);
-	if (om) {
-		ret = FrameAvailable;
-		ms_queue_put(output, om);
+	processPacket(im);
+	freemsg(im);
+
+	if (marker && mPendingFragment) {
+		ms_warning("ObuUnpacker: the temporal unit ends on an open OBU fragment. Dropping the frame.");
+		mFrameCorrupted = true;
+	}
+
+	// Report a corrupted frame once, on the packet that condemned it.
+	Status ret = (mFrameCorrupted && !wasCorrupted) ? FrameCorrupted : NoFrame;
+
+	if (marker) {
+		if (!mFrameCorrupted && mFrame) {
+			msgpullup(mFrame, -1);
+			ms_queue_put(output, mFrame);
+			mFrame = nullptr;
+			ret = FrameAvailable;
+		}
+		discardFrame();
 	}
 
 	return ret;
 }
 
-void ObuUnpacker::reset() {
-	if (mFrame) freemsg(mFrame);
-	mFrame = nullptr;
-	mInitializedRefCSeq = false;
-}
+void ObuUnpacker::processPacket(mblk_t *packet) {
+	uint8_t *cur = packet->b_rptr;
+	uint8_t *end = packet->b_wptr;
 
-mblk_t *ObuUnpacker::feed(mblk_t *packet) {
-	uint8_t *header = packet->b_rptr;
-	bool isFirst = (*header >> 3) & 0x1;
-	int marker = mblk_get_marker_info(packet);
-
-	// Remove aggregation header
-	packet->b_rptr += 1;
-
-	if (isAggregating() && isFirst) {
-		ms_error("ObuUnpacker: Received the first packet of a video sequence while already aggregating. Dropping the "
-		         "current frame.");
-		if (mFrame) freemsg(mFrame);
-		mFrame = packet;
-
-		return marker ? completeAggregation() : nullptr;
+	if (cur >= end) {
+		ms_warning("ObuUnpacker: empty payload. Dropping the frame.");
+		mFrameCorrupted = true;
+		return;
 	}
 
-	if (!isAggregating() && !isFirst) {
-		ms_error("ObuUnpacker: Received a continuation packet while aggregation is not started. Dropping packet.");
-		freemsg(packet);
+	const uint8_t aggregationHeader = *cur++;
+	const bool zBit = (aggregationHeader & 0x80) != 0;  // first element continues an OBU of the previous packet
+	const bool yBit = (aggregationHeader & 0x40) != 0;  // last element continues in the next packet
+	const int wField = (aggregationHeader >> 4) & 0x03; // element count, 0 = every element is length-prefixed
+	// N (0x08) flags a new coded video sequence; reassembly does not depend on it.
 
-		return nullptr;
+	if (cur >= end) {
+		ms_warning("ObuUnpacker: packet carries no OBU element. Dropping the frame.");
+		mFrameCorrupted = true;
+		return;
 	}
 
-	if (!isAggregating()) {
-		mFrame = packet;
-	} else {
-		concatb(mFrame, packet);
+	int index = 0;
+	while (cur < end) {
+		index++;
+		size_t elementSize;
+		if (wField == 0 || index < wField) {
+			uint64_t length;
+			size_t lengthBytes;
+			if (!readLeb128(cur, (size_t)(end - cur), length, lengthBytes) || length == 0 ||
+			    length > (size_t)(end - cur) - lengthBytes) {
+				ms_warning("ObuUnpacker: malformed OBU element length. Dropping the frame.");
+				mFrameCorrupted = true;
+				return;
+			}
+			cur += lengthBytes;
+			elementSize = (size_t)length;
+		} else {
+			// The last of the W announced elements extends to the end of the payload.
+			elementSize = (size_t)(end - cur);
+		}
+
+		const bool first = (index == 1);
+		const bool last = (cur + elementSize == end);
+		processObuElement(packet, cur, elementSize, first && zBit, last && yBit);
+		cur += elementSize;
 	}
 
-	return marker ? completeAggregation() : nullptr;
+	if (wField != 0 && index != wField) {
+		ms_warning("ObuUnpacker: expected %i OBU elements, got %i. Dropping the frame.", wField, index);
+		mFrameCorrupted = true;
+	}
 }
 
-bool ObuUnpacker::isAggregating() const {
-	return mFrame != nullptr;
+void ObuUnpacker::processObuElement(
+    mblk_t *packet, uint8_t *start, size_t size, bool continuesPrevious, bool willContinue) {
+	if (continuesPrevious && !mPendingFragment) {
+		// The head of this OBU was in a packet we never received (loss, or
+		// joining mid-stream): the element cannot be reassembled.
+		mFrameCorrupted = true;
+		return;
+	}
+	if (!continuesPrevious && mPendingFragment) {
+		// Defensive: an open fragment this element does not continue. It cannot
+		// happen without a sequence number gap, which already condemned the frame.
+		freemsg(mPendingFragment);
+		mPendingFragment = nullptr;
+		mFrameCorrupted = true;
+	}
+
+	// Reference the element bytes without copying them.
+	mblk_t *element = dupb(packet);
+	element->b_rptr = start;
+	element->b_wptr = start + size;
+
+	if (mPendingFragment) concatb(mPendingFragment, element);
+	else mPendingFragment = element;
+
+	if (!willContinue) appendCompleteObu();
 }
 
-mblk_t *ObuUnpacker::completeAggregation() {
-	if (!isAggregating()) return nullptr;
+void ObuUnpacker::appendCompleteObu() {
+	msgpullup(mPendingFragment, -1);
+	if (!rewriteObu(mPendingFragment->b_rptr, (size_t)(mPendingFragment->b_wptr - mPendingFragment->b_rptr))) {
+		mFrameCorrupted = true;
+	}
+	freemsg(mPendingFragment);
+	mPendingFragment = nullptr;
+}
 
-	mblk_t *om = mFrame;
-	msgpullup(om, -1);
+bool ObuUnpacker::rewriteObu(const uint8_t *data, size_t size) {
+	const uint8_t obuHeader = data[0];
+	const uint8_t obuType = (obuHeader >> 3) & 0x0f;
+	const bool hasExtension = (obuHeader & 0x04) != 0;
+	const bool hasSizeField = (obuHeader & 0x02) != 0;
+	const size_t headerSize = hasExtension ? 2 : 1;
 
-	mFrame = nullptr;
+	if (size < headerSize) {
+		ms_warning("ObuUnpacker: OBU shorter than its own header. Dropping the frame.");
+		return false;
+	}
 
-	return om;
+	const uint8_t *payload = data + headerSize;
+	size_t payloadSize = size - headerSize;
+
+	// The sender may have kept obu_size on the wire (the specification
+	// recommends omitting it but allows it). Strip it: the rewritten OBU
+	// carries its own.
+	if (hasSizeField) {
+		uint64_t declaredSize;
+		size_t lengthBytes;
+		if (!readLeb128(payload, payloadSize, declaredSize, lengthBytes)) {
+			ms_warning("ObuUnpacker: malformed obu_size field. Dropping the frame.");
+			return false;
+		}
+		payload += lengthBytes;
+		payloadSize -= lengthBytes;
+		if (declaredSize > payloadSize) {
+			ms_warning("ObuUnpacker: obu_size larger than the OBU element. Dropping the frame.");
+			return false;
+		}
+		// A smaller obu_size flags trailing padding: follow it.
+		payloadSize = (size_t)declaredSize;
+	}
+
+	// Forbidden on the wire and rebuilt by no one: a temporal delimiter that
+	// arrives anyway is dropped, not treated as an error.
+	if (obuType == kObuTypeTemporalDelimiter) return true;
+
+	mblk_t *obu = allocb(headerSize + 8 + payloadSize, 0);
+	*obu->b_wptr++ = obuHeader | 0x02;
+	if (hasExtension) *obu->b_wptr++ = data[1];
+	obu->b_wptr += writeLeb128(obu->b_wptr, payloadSize);
+	memcpy(obu->b_wptr, payload, payloadSize);
+	obu->b_wptr += payloadSize;
+
+	if (mFrame) concatb(mFrame, obu);
+	else mFrame = obu;
+
+	return true;
 }
 
 } // namespace mediastreamer

--- a/mediastreamer2/src/videofilters/av1/obu/obu-unpacker.h
+++ b/mediastreamer2/src/videofilters/av1/obu/obu-unpacker.h
@@ -26,6 +26,30 @@
 
 namespace mediastreamer {
 
+/**
+ * Reassembles temporal units from RTP packets carrying the "RTP Payload Format
+ * For AV1" (AOMedia specification, v1.0).
+ *
+ * Each packet starts with the aggregation header:
+ *
+ *     0 1 2 3 4 5 6 7
+ *    +-+-+-+-+-+-+-+-+
+ *    |Z|Y| W |N|-|-|-|
+ *    +-+-+-+-+-+-+-+-+
+ *
+ * and carries one or more OBU elements. When W is 0 every element is prefixed
+ * by its leb128 length; when W > 0 the packet holds exactly W elements, the
+ * first W-1 length-prefixed and the last one extending to the end of the
+ * payload. Z flags the first element as the continuation of an OBU started in
+ * the previous packet, Y flags the last element as continuing in the next
+ * packet, and the RTP marker bit closes the temporal unit.
+ *
+ * Senders are recommended to omit obu_size fields (the element length already
+ * carries the size), but may keep them. Whatever the input form, each
+ * reassembled OBU is rewritten with obu_has_size_field set, so the delivered
+ * temporal unit is a self-delimiting low-overhead bitstream that dav1d and
+ * obuparse can consume directly.
+ */
 class ObuUnpacker {
 public:
 	enum Status { NoFrame, FrameAvailable, FrameCorrupted };
@@ -35,12 +59,16 @@ public:
 	Status unpack(mblk_t *im, MSQueue *output);
 	void reset();
 
-protected:
-	mblk_t *feed(mblk_t *packet);
-	bool isAggregating() const;
-	mblk_t *completeAggregation();
+private:
+	void processPacket(mblk_t *packet);
+	void processObuElement(mblk_t *packet, uint8_t *start, size_t size, bool continuesPrevious, bool willContinue);
+	void appendCompleteObu();
+	bool rewriteObu(const uint8_t *data, size_t size);
+	void discardFrame();
 
-	mblk_t *mFrame = nullptr;
+	mblk_t *mFrame = nullptr;           // completed OBUs of the current temporal unit, in low-overhead format
+	mblk_t *mPendingFragment = nullptr; // OBU under reassembly, raw element bytes
+	bool mFrameCorrupted = false;
 	bool mInitializedRefCSeq = false;
 	uint16_t mRefCSeq = 0;
 };


### PR DESCRIPTION
`ObuUnpacker` cannot decode AV1 from a sender that follows the AOMedia
["RTP Payload Format For AV1" spec](https://aomediacodec.github.io/av1-rtp-spec/v1.0.0.html), for two reasons:

1. It reads the **N** bit as a frame-start marker. Per the spec, N is only set
   on the first packet of a coded video sequence (a key frame). A conformant
   sender therefore gets every inter frame dropped with
   `ObuUnpacker: Received a continuation packet while aggregation is not started`.
   (It interoperates with `ObuPacker` only because the latter sets N on every
   temporal unit.)
2. It concatenates payloads without rebuilding `obu_size`, ignoring W and the
   leb128 element lengths. The spec recommends senders omit `obu_size`; for
   such a sender, a key frame (sequence header + frame OBU) is not
   self-delimiting and dav1d fails on it.

This rewrites `ObuUnpacker` to implement the wire format: Z/Y/W and the RTP
marker drive reassembly (N is no longer used), and every reassembled OBU is
rewritten with `obu_has_size_field` set, so the delivered temporal unit is
always parsable by dav1d and `obuparse`. Loss and malformed input drop the
current temporal unit and report `FrameCorrupted` once (one PLI). The public
API is unchanged; `ObuPacker`'s stream is a subset of what is now accepted, so
mediastreamer2 → mediastreamer2 is unaffected.

Tested against both sender profiles (with and without `obu_size`), W=0/1/2,
Z/Y fragmentation, and six loss/malformation scenarios; every delivered frame
re-parsed with `obuparse`; valgrind clean. Validated in a real call: a
conformant AV1 sender that previously produced no video at all now decodes
continuously (720p, no ObuUnpacker errors, no decoding failures).